### PR TITLE
feat(function-properties-read-only)

### DIFF
--- a/packages/shell-chrome/assets/panel.html
+++ b/packages/shell-chrome/assets/panel.html
@@ -36,12 +36,10 @@
         <h2 class="flex text-2xl leading-9 tracking-tight font-extrabold text-gray-900 sm:text-4xl sm:leading-10">
             Alpine.js is Ready
         </h2>
-        <div
-            id="components"
-            x-data="{components : []}"
-            class="flex flex-1 flex-col sm:flex-row mt-6 border-t-2 border-gray-100 pt-10"
-        >
-            <div class="flex flex-col w-full sm:w-1/2 max-h-full border-solid sm:border-r border-gray-900 mb-6 pl-2 overflow-y-scroll">
+        <div id="components" x-data="{components : []}"
+            class="flex flex-1 flex-col sm:flex-row mt-6 border-t-2 border-gray-100 pt-10">
+            <div
+                class="flex flex-col w-full sm:w-1/2 max-h-full border-solid sm:border-r border-gray-900 mb-6 pl-2 overflow-y-scroll">
                 <h4 class="text-base" style="color:#486887">components</h4>
                 <template x-for="(component,index) in components">
                     <a :class="{'bg-blue-300' : component.isOpened}"
@@ -56,11 +54,11 @@
                 </template>
             </div>
 
-            <div class="flex flex-col w-full sm:w-1/2 border-solid border-t sm:border-t-0 pt-4 sm:pt-0 border-gray-900 pl-2 overflow-x-scroll h-full">
+            <div
+                class="flex flex-col w-full sm:w-1/2 border-solid border-t sm:border-t-0 pt-4 sm:pt-0 border-gray-900 pl-2 overflow-x-scroll h-full">
                 <h4 class="text-base" style="color:#486887">data</h4>
                 <template x-for="(singleComponent, componentIndex) in components">
                     <div x-show="singleComponent.isOpened">
-
                         <template x-for="(singleData,index) in singleComponent.flattenedData">
                             <div class="pl-2 flex" style="align-items: center;">
                                 <a :style="`margin-left: ${singleData.depth}px; `"
@@ -80,7 +78,8 @@
 
                                     </h5>
                                 </a>
-                                <span class="flex flex-col ml-2" x-show="!singleData.hasArrow && singleData.isOpened">
+                                <span class="flex flex-col ml-2"
+                                    x-show="!singleData.hasArrow && !singleData.readOnly && singleData.isOpened">
                                     <svg fill="none" stroke="currentColor" stroke-linecap="round"
                                         x-show="!singleData.inEditingMode"
                                         @click="alpineState.editAttribute(singleData)" stroke-linejoin="round"
@@ -92,8 +91,7 @@
                                     </svg>
 
                                     <div class="flex flex-row items-center">
-                                        <input
-                                            x-show="singleData.inEditingMode"
+                                        <input x-show="singleData.inEditingMode"
                                             class="flex w-2/3 shadow appearance-none border rounded py-1 px-1 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
                                             type="text" x-model="singleData.editAttributeValue">
 

--- a/packages/shell-chrome/assets/panel.html
+++ b/packages/shell-chrome/assets/panel.html
@@ -62,8 +62,9 @@
                         <template x-for="(singleData,index) in singleComponent.flattenedData">
                             <div class="pl-2 flex" style="align-items: center;">
                                 <a :style="`margin-left: ${singleData.depth}px; `"
-                                    @click="alpineState.toggleDataAttribute(singleData)"
-                                    class="block component cursor-pointer" x-show="singleData.isOpened">
+                                    @click="alpineState.toggleDataAttribute(singleData)" class="block" :class="{
+                                        'component cursor-pointer': !singleData.readOnly
+                                    }" x-show="singleData.isOpened">
 
                                     <h5 class="leading-7 flex items-center">
                                         <span x-show="singleData.hasArrow" class="arrow"

--- a/packages/shell-chrome/src/backend.js
+++ b/packages/shell-chrome/src/backend.js
@@ -106,7 +106,10 @@ function discoverComponents(isThroughMutation = false) {
     var data = {};
 
     for (let [key, value] of Object.entries(rootEl.__x.getUnobservedData())) {
-      data[key] = typeof value == "function" ? "function" : value;
+        data[key] = {
+            value: typeof value === "function" ? "function" : value,
+            type: typeof value
+        }
     }
 
     components.push({

--- a/packages/shell-chrome/src/state.js
+++ b/packages/shell-chrome/src/state.js
@@ -65,6 +65,8 @@ export default class State {
   }
 
   toggleDataAttribute(attribute) {
+    // don't toggle anything if the attribute is read-only
+    if (attribute.readOnly) return;
     if (attribute.hasArrow) {
       let childrenIdLength = attribute.id.split("*").length + 1;
 

--- a/packages/shell-chrome/src/utils.js
+++ b/packages/shell-chrome/src/utils.js
@@ -1,8 +1,8 @@
 export function flattenData(data) {
   let flattenedData = [];
- 
+
   for (var key in data) {
-    flattenSingleAttribute(flattenedData, key, data[key]);
+    flattenSingleAttribute(flattenedData, key, data[key].value, data[key].type);
   }
 
   return flattenedData;
@@ -12,6 +12,7 @@ export function flattenSingleAttribute(
   flattenedData,
   attributeName,
   value,
+  type,
   margin = 0,
   id = "",
   directParentId = '',
@@ -48,6 +49,7 @@ export function flattenSingleAttribute(
         flattenedData,
         index,
         value[index],
+        typeof value,
         margin,
         (id ? id : attributeName) + "*" + index,
         id ? id : attributeName

--- a/packages/shell-chrome/src/utils.js
+++ b/packages/shell-chrome/src/utils.js
@@ -33,6 +33,7 @@ export function flattenSingleAttribute(
       : value,
     depth: margin,
     hasArrow: value instanceof Object,
+    readOnly: type === 'function',
     id: generatedId,
     inEditingMode: false,
     isOpened : id.length == 0,

--- a/packages/shell-chrome/src/utils.js
+++ b/packages/shell-chrome/src/utils.js
@@ -64,6 +64,7 @@ export function flattenSingleAttribute(
         flattenedData,
         objectKey,
         value[objectKey],
+        typeof value[objectKey],
         margin,
         (id ? id : attributeName) + "*" + objectKey,
         id ? id : attributeName


### PR DESCRIPTION
Closes #6 
- make component data `[key]: { value, type }` instead of `[key]: value`
- set `readOnly` for "function" properties
- update styling and what displays based on `readOnly`

FYI since I'll need the shape (`type`) changes for the boolean input, I'll branch from this 😄 