### PR TITLE
feat(bool-checkbox)

### DIFF
--- a/packages/shell-chrome/assets/panel.html
+++ b/packages/shell-chrome/assets/panel.html
@@ -94,7 +94,7 @@
                                     <div class="flex flex-row items-center">
                                         <input x-show="singleData.inEditingMode"
                                             class="flex w-2/3 shadow appearance-none border rounded py-1 px-1 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
-                                            type="text" x-model="singleData.editAttributeValue">
+                                            :type="singleData.inputType" x-model="singleData.editAttributeValue">
 
                                         <svg x-show="singleData.inEditingMode" fill="none" stroke="currentColor"
                                             @click="alpineState.saveEditing(singleData)" stroke-linecap="round"

--- a/packages/shell-chrome/src/backend.js
+++ b/packages/shell-chrome/src/backend.js
@@ -57,16 +57,23 @@ function handleMessages(e) {
           var splittedAttrs = e.data.payload.attributeSequence.split("*");
 
           for (index in splittedAttrs) {
-            attributes = attributes + '["' + splittedAttrs[index] + '"]';
+            attributes += '["' + splittedAttrs[index] + '"]';
           }
 
           var data = component.__x.getUnobservedData();
 
-          eval(`(data${attributes} = '${e.data.payload.attributeValue}')`);
-          component.__x.$el.setAttribute("x-data", `${JSON.stringify(data)}`);
+          // nested path descriptor, eg. array*0*property needs to update array[0].property
+          if (attributeSequence.includes('*')) {
+            eval(`(data${attributes} = '${e.data.payload.attributeValue}')`);
+          } else {
+            // don't need "eval" to set single top-level attribute
+            data[e.data.payload.attributeSequence] = e.data.payload.attributeValue;
+          }
+
+          component.__x.$el.setAttribute("x-data", JSON.stringify(data));
         }
         setTimeout(() => {
-          window.__alpineDevtool["stopMutationObserver"] = false;
+          window.__alpineDevtool.stopMutationObserver = false;
         }, 10);
       });
     }

--- a/packages/shell-chrome/src/state.js
+++ b/packages/shell-chrome/src/state.js
@@ -164,7 +164,7 @@ export default class State {
     this.components[clickedAttribute.parentComponentId].flattenedData.forEach(
       (f) => {
         if (f.id == clickedAttribute.id) {
-          f.attributeValue = clickedAttribute.editAttributeValue;
+          f.attributeValue = clickedAttribute.attributeValue;
         }
       }
     );

--- a/packages/shell-chrome/src/utils.js
+++ b/packages/shell-chrome/src/utils.js
@@ -10,9 +10,11 @@ export function flattenData(data) {
 
 function mapDataTypeToInputType(dataType) {
     switch(dataType) {
-        case 'boolean': return 'checkbox';
-        case 'number': return 'number';
-        case 'string':
+        case 'boolean':
+            return 'checkbox';
+        case 'number':
+            return 'number';
+        // strings will fall through to "text"
         default:
             return 'text';
     }

--- a/packages/shell-chrome/src/utils.js
+++ b/packages/shell-chrome/src/utils.js
@@ -8,6 +8,16 @@ export function flattenData(data) {
   return flattenedData;
 }
 
+function mapDataTypeToInputType(dataType) {
+    switch(dataType) {
+        case 'boolean': return 'checkbox';
+        case 'number': return 'number';
+        case 'string':
+        default:
+            return 'text';
+    }
+}
+
 export function flattenSingleAttribute(
   flattenedData,
   attributeName,
@@ -34,6 +44,7 @@ export function flattenSingleAttribute(
     depth: margin,
     hasArrow: value instanceof Object,
     readOnly: type === 'function',
+    inputType: mapDataTypeToInputType(type),
     id: generatedId,
     inEditingMode: false,
     isOpened : id.length == 0,


### PR DESCRIPTION
Should not be merged before #21 

Closes #13 

- populate an `inputType` for each component based on data type (string -> text, boolean -> checkbox, number -> number)
- fix number/boolean data injection for top-level properties
  - `eval(data ...` was always quoting the content so don't use it for top-level fields (ie. attributeSequence has no `*`)

Fix for non-top-level boolean/number in #23