### PR TITLE
fix(number-input) chore(remove-eval) 

### DIFF
--- a/packages/shell-chrome/src/backend.js
+++ b/packages/shell-chrome/src/backend.js
@@ -1,4 +1,19 @@
-import { set } from "./utils";
+/**
+* Loose port of Lodash#set with "." as the delimiter, see https://lodash.com/docs#set
+*
+* @param {object} object - object to update
+* @param {string} path - path to set in the form `a.0.b.c`
+* @param {any} value - value to set to
+*/
+function set(object, path, value) {
+    const [nextProperty, ...rest] = path.split('.');
+    if (rest.length === 0) {
+        object[nextProperty] = value;
+        return object;
+    }
+    set(object[nextProperty], rest.join('.'), value);
+    return object
+}
 
 window.addEventListener("message", handshake);
 window.__alpineDevtool = {};
@@ -57,12 +72,9 @@ function handleMessages(e) {
                     const data = component.__x.getUnobservedData();
                     const { attributeSequence, attributeValue } = e.data.payload;
 
-                    // nested path descriptor, eg. array*0*property needs to update array[0].property
-                    if (attributeSequence.includes("*")) {
-                        // convert array*0*property to array.0.property
-                        // to pass to the set function
-                        const attributePath = attributeSequence.replace(/\*/g, ".");
-                        set(data, attributePath, attributeValue);
+                    // nested path descriptor, eg. array.0.property needs to update array[0].property
+                    if (attributeSequence.includes(".")) {
+                        set(data, attributeSequence, attributeValue);
                     } else {
                         data[attributeSequence] = attributeValue;
                     }

--- a/packages/shell-chrome/src/backend.js
+++ b/packages/shell-chrome/src/backend.js
@@ -1,155 +1,155 @@
-import { set } from './utils';
+import { set } from "./utils";
 
 window.addEventListener("message", handshake);
 window.__alpineDevtool = {};
 
 function handshake(e) {
-  if (e.data.source === "alpine-devtools-proxy" && e.data.payload === "init") {
-    window.removeEventListener("message", handshake);
-    window.addEventListener("message", handleMessages);
+    if (e.data.source === "alpine-devtools-proxy" && e.data.payload === "init") {
+        window.removeEventListener("message", handshake);
+        window.addEventListener("message", handleMessages);
 
-    discoverComponents();
+        discoverComponents();
 
-    document.querySelectorAll("[x-data]").forEach((el) => observeNode(el));
-  }
+        document.querySelectorAll("[x-data]").forEach((el) => observeNode(el));
+    }
 }
 
 function handleMessages(e) {
-  if (e.data.source == "alpine-devtools-proxy") {
-    window.__alpineDevtool["stopMutationObserver"] = true;
+    if (e.data.source === "alpine-devtools-proxy") {
+        window.__alpineDevtool.stopMutationObserver = true;
 
-    if (e.data.payload.action == "hover") {
-      Alpine.discoverComponents((component) => {
-        if (
-          component.__alpineDevtool &&
-          component.__alpineDevtool.id == e.data.payload.componentId
-        ) {
-          component.__alpineDevtool.backgroundColor =
-            component.__x.$el.style.backgroundColor;
-          component.__x.$el.style.backgroundColor = "rgba(104, 182, 255, 0.35)";
-        }
-        setTimeout(() => {
-          window.__alpineDevtool["stopMutationObserver"] = false;
-        }, 10);
-      });
-    }
-
-    if (e.data.payload.action == "hoverLeft") {
-      window.__alpineDevtool["stopMutationObserver"] = true;
-
-      Alpine.discoverComponents((component) => {
-        if (
-          component.__alpineDevtool &&
-          component.__alpineDevtool.id == e.data.payload.componentId
-        ) {
-          component.__x.$el.style.backgroundColor =
-            component.__alpineDevtool.backgroundColor;
-        }
-      });
-      setTimeout(() => {
-        window.__alpineDevtool["stopMutationObserver"] = false;
-      }, 10);
-    }
-
-    if (e.data.payload.action == "editAttribute") {
-        Alpine.discoverComponents((component) => {
-            if (component.__alpineDevtool.id == e.data.payload.componentId) {
-                const data = component.__x.getUnobservedData();
-                const { attributeSequence, attributeValue } = e.data.payload;
-
-                // nested path descriptor, eg. array*0*property needs to update array[0].property
-                if (attributeSequence.includes('*')) {
-                    // convert array*0*property to array.0.property
-                    // to pass to the set function
-                    const attributePath = attributeSequence.replace(/\*/g, '.');
-                    set(data, attributePath, attributeValue);
-                } else {
-                    data[attributeSequence] = attributeValue;
+        if (e.data.payload.action == "hover") {
+            Alpine.discoverComponents((component) => {
+                if (
+                    component.__alpineDevtool &&
+                    component.__alpineDevtool.id == e.data.payload.componentId
+                ) {
+                    component.__alpineDevtool.backgroundColor =
+                        component.__x.$el.style.backgroundColor;
+                    component.__x.$el.style.backgroundColor = "rgba(104, 182, 255, 0.35)";
                 }
+                setTimeout(() => {
+                    window.__alpineDevtool.stopMutationObserver = false;
+                }, 10);
+            });
+        }
 
-                component.__x.$el.setAttribute("x-data", JSON.stringify(data));
-            }
+        if (e.data.payload.action == "hoverLeft") {
+            window.__alpineDevtool.stopMutationObserver = true;
+
+            Alpine.discoverComponents((component) => {
+                if (
+                    component.__alpineDevtool &&
+                    component.__alpineDevtool.id === e.data.payload.componentId
+                ) {
+                    component.__x.$el.style.backgroundColor =
+                        component.__alpineDevtool.backgroundColor;
+                }
+            });
             setTimeout(() => {
                 window.__alpineDevtool.stopMutationObserver = false;
             }, 10);
-        });
+        }
+
+        if (e.data.payload.action == "editAttribute") {
+            Alpine.discoverComponents((component) => {
+                if (component.__alpineDevtool.id == e.data.payload.componentId) {
+                    const data = component.__x.getUnobservedData();
+                    const { attributeSequence, attributeValue } = e.data.payload;
+
+                    // nested path descriptor, eg. array*0*property needs to update array[0].property
+                    if (attributeSequence.includes("*")) {
+                        // convert array*0*property to array.0.property
+                        // to pass to the set function
+                        const attributePath = attributeSequence.replace(/\*/g, ".");
+                        set(data, attributePath, attributeValue);
+                    } else {
+                        data[attributeSequence] = attributeValue;
+                    }
+
+                    component.__x.$el.setAttribute("x-data", JSON.stringify(data));
+                }
+                setTimeout(() => {
+                    window.__alpineDevtool.stopMutationObserver = false;
+                }, 10);
+            });
+        }
     }
-  }
 }
 
 function discoverComponents(isThroughMutation = false) {
-  var rootEls = document.querySelectorAll("[x-data]");
+    var rootEls = document.querySelectorAll("[x-data]");
 
-  var components = [];
+    var components = [];
 
-  rootEls.forEach((rootEl, index) => {
-    Alpine.initializeComponent(rootEl);
+    rootEls.forEach((rootEl, index) => {
+        Alpine.initializeComponent(rootEl);
 
-    if (!rootEl.__alpineDevtool) {
-      rootEl.__alpineDevtool = {};
-    }
-
-    if (!isThroughMutation) {
-      rootEl.__alpineDevtool["id"] = Math.floor(Math.random() * 100000 + 1);
-    }
-
-    var depth = 0;
-
-    if (index != 0) {
-      rootEls.forEach((innerElement, innerIndex) => {
-        if (index == innerIndex) {
-          return false;
+        if (!rootEl.__alpineDevtool) {
+            rootEl.__alpineDevtool = {};
         }
 
-        if (innerElement.contains(rootEl)) {
-          depth = depth + 1;
+        if (!isThroughMutation) {
+            rootEl.__alpineDevtool.id = Math.floor(Math.random() * 100000 + 1);
         }
-      });
-    }
 
-    var data = {};
+        var depth = 0;
 
-    for (let [key, value] of Object.entries(rootEl.__x.getUnobservedData())) {
-        data[key] = {
-            value: typeof value === "function" ? "function" : value,
-            type: typeof value
+        if (index != 0) {
+            rootEls.forEach((innerElement, innerIndex) => {
+                if (index == innerIndex) {
+                    return false;
+                }
+
+                if (innerElement.contains(rootEl)) {
+                    depth = depth + 1;
+                }
+            });
         }
-    }
 
-    components.push({
-      tagName: rootEl.tagName,
-      depth: depth,
-      data: data,
-      index: index,
-      id: rootEl.__alpineDevtool["id"],
+        var data = {};
+
+        for (let [key, value] of Object.entries(rootEl.__x.getUnobservedData())) {
+            data[key] = {
+                value: typeof value === "function" ? "function" : value,
+                type: typeof value
+            }
+        }
+
+        components.push({
+            tagName: rootEl.tagName,
+            depth: depth,
+            data: data,
+            index: index,
+            id: rootEl.__alpineDevtool.id,
+        });
     });
-  });
 
-  window.postMessage(
-    {
-      source: "alpine-devtools-backend",
-      payload: {
-        components: components,
-        type: "render-components",
-        isThroughMutation: isThroughMutation,
-      },
-    },
-    "*"
-  );
+    window.postMessage(
+        {
+            source: "alpine-devtools-backend",
+            payload: {
+                components: components,
+                type: "render-components",
+                isThroughMutation: isThroughMutation,
+            },
+        },
+        "*"
+    );
 }
 
 function observeNode(node) {
-  const observerOptions = {
-    childList: true,
-    attributes: true,
-    subtree: true,
-  };
+    const observerOptions = {
+        childList: true,
+        attributes: true,
+        subtree: true,
+    };
 
-  const observer = new MutationObserver((mutations) => {
-    if (!window.__alpineDevtool["stopMutationObserver"]) {
-      discoverComponents((isThroughMutation = true));
-    }
-  });
+    const observer = new MutationObserver((mutations) => {
+        if (!window.__alpineDevtool.stopMutationObserver) {
+            discoverComponents((isThroughMutation = true));
+        }
+    });
 
-  observer.observe(node, observerOptions);
+    observer.observe(node, observerOptions);
 }

--- a/packages/shell-chrome/src/panel.js
+++ b/packages/shell-chrome/src/panel.js
@@ -1,6 +1,6 @@
 import './style.css'
 import State from "./state";
-import 'alpinejs'
+import 'alpinejs';
 
 injectScript(chrome.runtime.getURL("./backend.js"), () => {
   window.alpineState = new State();

--- a/packages/shell-chrome/src/state.js
+++ b/packages/shell-chrome/src/state.js
@@ -1,4 +1,4 @@
-import { flattenData } from "./utils";
+import { flattenData, convertInputDataToType } from "./utils";
 
 export default class State {
   constructor() {
@@ -68,7 +68,7 @@ export default class State {
     // don't toggle anything if the attribute is read-only
     if (attribute.readOnly) return;
     if (attribute.hasArrow) {
-      let childrenIdLength = attribute.id.split("*").length + 1;
+      let childrenIdLength = attribute.id.split(".").length + 1;
 
       //this code generate something like that \\w+\\*\\w+\\*\\w+$
       let closeRegexStr = "";
@@ -93,8 +93,8 @@ export default class State {
         }
 
         return (
-          a.startsWith(attribute.id + "*") &&
-          a.split("*").length == childrenIdLength
+          a.startsWith(attribute.id + ".") &&
+          a.split(".").length == childrenIdLength
         );
       });
 
@@ -138,7 +138,7 @@ export default class State {
   }
 
   hoverOnComponent(component) {
-    window.__alpineDevtool["port"].postMessage({
+    window.__alpineDevtool.port.postMessage({
       componentId: component.id,
       action: "hover",
       source: "alpineDevtool",
@@ -146,7 +146,7 @@ export default class State {
   }
 
   hoverLeftComponent(component) {
-    window.__alpineDevtool["port"].postMessage({
+    window.__alpineDevtool.port.postMessage({
       componentId: component.id,
       action: "hoverLeft",
       source: "alpineDevtool",
@@ -158,7 +158,7 @@ export default class State {
   }
 
   saveEditing(clickedAttribute) {
-    clickedAttribute.attributeValue = clickedAttribute.editAttributeValue;
+    clickedAttribute.attributeValue = convertInputDataToType(clickedAttribute.inputType, clickedAttribute.editAttributeValue);
     clickedAttribute.inEditingMode = false;
 
     this.components[clickedAttribute.parentComponentId].flattenedData.forEach(
@@ -169,7 +169,7 @@ export default class State {
       }
     );
 
-    window.__alpineDevtool["port"].postMessage({
+    window.__alpineDevtool.port.postMessage({
       componentId: clickedAttribute.parentComponentId,
       attributeSequence: clickedAttribute.id,
       attributeValue: clickedAttribute.attributeValue,

--- a/packages/shell-chrome/src/utils.js
+++ b/packages/shell-chrome/src/utils.js
@@ -1,15 +1,15 @@
 export function flattenData(data) {
-  let flattenedData = [];
+    let flattenedData = [];
 
-  for (var key in data) {
-    flattenSingleAttribute(flattenedData, key, data[key].value, data[key].type);
-  }
+    for (var key in data) {
+        flattenSingleAttribute(flattenedData, key, data[key].value, data[key].type);
+    }
 
-  return flattenedData;
+    return flattenedData;
 }
 
 function mapDataTypeToInputType(dataType) {
-    switch(dataType) {
+    switch (dataType) {
         case 'boolean':
             return 'checkbox';
         case 'number':
@@ -21,70 +21,70 @@ function mapDataTypeToInputType(dataType) {
 }
 
 export function flattenSingleAttribute(
-  flattenedData,
-  attributeName,
-  value,
-  type,
-  margin = 0,
-  id = "",
-  directParentId = '',
+    flattenedData,
+    attributeName,
+    value,
+    type,
+    margin = 0,
+    id = "",
+    directParentId = '',
 ) {
-  let generatedId = id ? id : attributeName;
+    let generatedId = id ? id : attributeName;
 
-  flattenedData.push({
-    attributeName: attributeName,
-    attributeValue: Array.isArray(value)
-      ? "Array"
-      : value instanceof Object
-      ? "Object"
-      : value,
-    editAttributeValue: Array.isArray(value)
-      ? "Array"
-      : value instanceof Object
-      ? "Object"
-      : value,
-    depth: margin,
-    hasArrow: value instanceof Object,
-    readOnly: type === 'function',
-    inputType: mapDataTypeToInputType(type),
-    id: generatedId,
-    inEditingMode: false,
-    isOpened : id.length == 0,
-    isArrowDown : false,
-    directParentId: directParentId
-  });
+    flattenedData.push({
+        attributeName: attributeName,
+        attributeValue: Array.isArray(value)
+            ? "Array"
+            : value instanceof Object
+                ? "Object"
+                : value,
+        editAttributeValue: Array.isArray(value)
+            ? "Array"
+            : value instanceof Object
+                ? "Object"
+                : value,
+        depth: margin,
+        hasArrow: value instanceof Object,
+        readOnly: type === 'function',
+        inputType: mapDataTypeToInputType(type),
+        id: generatedId,
+        inEditingMode: false,
+        isOpened: id.length == 0,
+        isArrowDown: false,
+        directParentId: directParentId
+    });
 
-  if (Array.isArray(value)) {
-    margin = margin + 10;
+    if (Array.isArray(value)) {
+        margin = margin + 10;
 
-    for (var index in value) {
+        for (var index in value) {
 
-      flattenSingleAttribute(
-        flattenedData,
-        index,
-        value[index],
-        typeof value,
-        margin,
-        (id ? id : attributeName) + "*" + index,
-        id ? id : attributeName
-      );
+            flattenSingleAttribute(
+                flattenedData,
+                index,
+                value[index],
+                typeof value,
+                margin,
+                (id ? id : attributeName) + "*" + index,
+                id ? id : attributeName
+            );
+        }
+    } else if (value instanceof Object) {
+        margin = margin + 10;
+
+        for (var objectKey in value) {
+            flattenSingleAttribute(
+                flattenedData,
+                objectKey,
+                value[objectKey],
+                typeof value[objectKey],
+                margin,
+                (id ? id : attributeName) + "*" + objectKey,
+                id ? id : attributeName
+
+            );
+        }
     }
-  } else if (value instanceof Object) {
-    margin = margin + 10;
-
-    for (var objectKey in value) {
-      flattenSingleAttribute(
-        flattenedData,
-        objectKey,
-        value[objectKey],
-        typeof value[objectKey],
-        margin,
-        (id ? id : attributeName) + "*" + objectKey,
-        id ? id : attributeName
-
-      );
-    }
-  }
 }
 
 /**
@@ -95,11 +95,11 @@ export function flattenSingleAttribute(
 * @param {any} value - value to set to
 */
 export function set(object, path, value) {
-   const [nextProperty, ...rest] = path.split('.');
-   if (rest.length === 0){
-       object[nextProperty] = value;
-       return object;
-   }
-   set(object[nextProperty], rest.join('.'), value);
-   return object
+    const [nextProperty, ...rest] = path.split('.');
+    if (rest.length === 0) {
+        object[nextProperty] = value;
+        return object;
+    }
+    set(object[nextProperty], rest.join('.'), value);
+    return object
 }

--- a/packages/shell-chrome/src/utils.js
+++ b/packages/shell-chrome/src/utils.js
@@ -86,3 +86,20 @@ export function flattenSingleAttribute(
     }
   }
 }
+
+/**
+* Loose port of Lodash#set with "." as the delimiter, see https://lodash.com/docs#set
+*
+* @param {object} object - object to update
+* @param {string} path - path to set in the form `a.0.b.c`
+* @param {any} value - value to set to
+*/
+export function set(object, path, value) {
+   const [nextProperty, ...rest] = path.split('.');
+   if (rest.length === 0){
+       object[nextProperty] = value;
+       return object;
+   }
+   set(object[nextProperty], rest.join('.'), value);
+   return object
+}

--- a/packages/shell-chrome/src/utils.js
+++ b/packages/shell-chrome/src/utils.js
@@ -1,6 +1,7 @@
 export function flattenData(data) {
     let flattenedData = [];
 
+    console.log(data);
     for (var key in data) {
         flattenSingleAttribute(flattenedData, key, data[key].value, data[key].type);
     }
@@ -20,6 +21,16 @@ function mapDataTypeToInputType(dataType) {
     }
 }
 
+export function convertInputDataToType(inputType, value) {
+    switch (inputType) {
+        case 'number':
+            return parseFloat(value);
+        // checkbox and text are already the right type
+        default:
+            return value;
+    }
+}
+
 export function flattenSingleAttribute(
     flattenedData,
     attributeName,
@@ -29,7 +40,7 @@ export function flattenSingleAttribute(
     id = "",
     directParentId = '',
 ) {
-    let generatedId = id ? id : attributeName;
+    const generatedId = id ? id : attributeName;
 
     flattenedData.push({
         attributeName: attributeName,
@@ -55,51 +66,30 @@ export function flattenSingleAttribute(
     });
 
     if (Array.isArray(value)) {
-        margin = margin + 10;
-
-        for (var index in value) {
-
+        value.forEach((val, index) => {
+            const elementId = id ? id : attributeName;
             flattenSingleAttribute(
                 flattenedData,
                 index,
-                value[index],
-                typeof value,
-                margin,
-                (id ? id : attributeName) + "*" + index,
-                id ? id : attributeName
+                val,
+                typeof val,
+                margin + 10,
+                `${elementId}.${index}`,
+                elementId
             );
-        }
+        });
     } else if (value instanceof Object) {
-        margin = margin + 10;
-
-        for (var objectKey in value) {
+        Object.keys(value).forEach((objectKey) => {
+            const elementId = id ? id : attributeName;
             flattenSingleAttribute(
                 flattenedData,
                 objectKey,
                 value[objectKey],
                 typeof value[objectKey],
-                margin,
-                (id ? id : attributeName) + "*" + objectKey,
-                id ? id : attributeName
-
+                margin + 10,
+                `${elementId}.${objectKey}`,
+                elementId
             );
-        }
+        });
     }
-}
-
-/**
-* Loose port of Lodash#set with "." as the delimiter, see https://lodash.com/docs#set
-*
-* @param {object} object - object to update
-* @param {string} path - path to set in the form `a.0.b.c`
-* @param {any} value - value to set to
-*/
-export function set(object, path, value) {
-    const [nextProperty, ...rest] = path.split('.');
-    if (rest.length === 0) {
-        object[nextProperty] = value;
-        return object;
-    }
-    set(object[nextProperty], rest.join('.'), value);
-    return object
 }

--- a/packages/shell-chrome/src/utils.js
+++ b/packages/shell-chrome/src/utils.js
@@ -1,7 +1,6 @@
 export function flattenData(data) {
     let flattenedData = [];
 
-    console.log(data);
     for (var key in data) {
         flattenSingleAttribute(flattenedData, key, data[key].value, data[key].type);
     }
@@ -79,13 +78,13 @@ export function flattenSingleAttribute(
             );
         });
     } else if (value instanceof Object) {
-        Object.keys(value).forEach((objectKey) => {
+        Object.entries(value).forEach(([objectKey, objectValue]) => {
             const elementId = id ? id : attributeName;
             flattenSingleAttribute(
                 flattenedData,
                 objectKey,
-                value[objectKey],
-                typeof value[objectKey],
+                objectValue,
+                typeof objectValue,
                 margin + 10,
                 `${elementId}.${objectKey}`,
                 elementId


### PR DESCRIPTION
Closes #26 
Refactor of backend.js to remove `eval` since it's not strictly necessary & causes a Rollup warning.

- **fix**: setting non-top-level properties to boolean/number
- **fix**: coerce number inputs to number values before updating them in Alpine

Changes:

- create a `set` function inspired by `lodash.set` (see https://lodash.com/docs#set) so we can do `set(data, 'array.0.property.nestedProperty', 'newValue')` instead of using `eval`.
- use `set` in backend.js instead of `eval`.
- format all edited files to 4-space indent
- refactor `flattenSingleAttribute` for Array/Object to be more compact
- change path separator from `*` eg. `array*0*property` to `.`, eg. `array.0.property`