### PR TITLE
fix(un-proxy-with-json-serialisation)

### DIFF
--- a/packages/shell-chrome/src/backend.js
+++ b/packages/shell-chrome/src/backend.js
@@ -119,15 +119,14 @@ function discoverComponents(isThroughMutation = false) {
             });
         }
 
-        var data = {};
-
-        for (let [key, value] of Object.entries(rootEl.__x.getUnobservedData())) {
+        const data = Object.entries(rootEl.__x.getUnobservedData()).reduce((acc, [key, value]) => {
             const type = typeof value;
-            data[key] = {
+            acc[key] = {
                 value: type === "function" ? "function" : value,
                 type
             }
-        }
+            return acc;
+        }, {})
 
         components.push({
             tagName: rootEl.tagName,

--- a/packages/shell-chrome/src/backend.js
+++ b/packages/shell-chrome/src/backend.js
@@ -122,9 +122,10 @@ function discoverComponents(isThroughMutation = false) {
         var data = {};
 
         for (let [key, value] of Object.entries(rootEl.__x.getUnobservedData())) {
+            const type = typeof value;
             data[key] = {
-                value: typeof value === "function" ? "function" : value,
-                type: typeof value
+                value: type === "function" ? "function" : value,
+                type
             }
         }
 
@@ -141,7 +142,10 @@ function discoverComponents(isThroughMutation = false) {
         {
             source: "alpine-devtools-backend",
             payload: {
-                components: components,
+                // stringify to deal with proxies
+                // there's no way to detect proxies but
+                // we need to get rid of them
+                components: JSON.stringify(components),
                 type: "render-components",
                 isThroughMutation: isThroughMutation,
             },

--- a/packages/shell-chrome/src/backend.js
+++ b/packages/shell-chrome/src/backend.js
@@ -142,9 +142,11 @@ function discoverComponents(isThroughMutation = false) {
         {
             source: "alpine-devtools-backend",
             payload: {
-                // stringify to deal with proxies
+                // stringify to unfurl proxies
                 // there's no way to detect proxies but
                 // we need to get rid of them
+                // this avoids `DataCloneError: The object could not be cloned.`
+                // see https://github.com/Te7a-Houdini/alpinejs-devtools/issues/17
                 components: JSON.stringify(components),
                 type: "render-components",
                 isThroughMutation: isThroughMutation,

--- a/packages/shell-chrome/src/panel.js
+++ b/packages/shell-chrome/src/panel.js
@@ -20,7 +20,7 @@ injectScript(chrome.runtime.getURL("./backend.js"), () => {
 
   port.onMessage.addListener(function (message) {
     if (message.type == "render-components") {
-      alpineState.renderComponentsFromBackend(message.components);
+      alpineState.renderComponentsFromBackend(JSON.parse(message.components));
 
       window.__alpineDevtool["port"] = port;
     }

--- a/packages/shell-chrome/src/panel.js
+++ b/packages/shell-chrome/src/panel.js
@@ -3,28 +3,28 @@ import State from "./state";
 import 'alpinejs';
 
 injectScript(chrome.runtime.getURL("./backend.js"), () => {
-  window.alpineState = new State();
+    window.alpineState = new State();
+    window.__alpineDevtool = {};
 
-  // 2. connect to background to setup proxy
-  const port = chrome.runtime.connect({
-    name: "" + chrome.devtools.inspectedWindow.tabId,
-  });
+    // 2. connect to background to setup proxy
+    const port = chrome.runtime.connect({
+        name: "" + chrome.devtools.inspectedWindow.tabId,
+    });
 
-  let disconnected = false;
+    let disconnected = false;
 
-  port.onDisconnect.addListener(() => {
-    disconnected = true;
-  });
+    port.onDisconnect.addListener(() => {
+        disconnected = true;
+    });
 
-  window.__alpineDevtool = {};
+    port.onMessage.addListener(function (message) {
+        if (message.type == "render-components") {
+            // message.components is a serialised JSON string
+            alpineState.renderComponentsFromBackend(JSON.parse(message.components));
 
-  port.onMessage.addListener(function (message) {
-    if (message.type == "render-components") {
-      alpineState.renderComponentsFromBackend(JSON.parse(message.components));
-
-      window.__alpineDevtool["port"] = port;
-    }
-  });
+            window.__alpineDevtool.port = port;
+        }
+    });
 });
 
 /**
@@ -36,7 +36,7 @@ injectScript(chrome.runtime.getURL("./backend.js"), () => {
  */
 
 function injectScript(scriptName, cb) {
-  const src = `
+    const src = `
     (function() {
       var script = document.constructor.prototype.createElement.call(document, 'script');
       script.src = "${scriptName}";
@@ -44,10 +44,10 @@ function injectScript(scriptName, cb) {
       script.parentNode.removeChild(script);
     })()
   `;
-  chrome.devtools.inspectedWindow.eval(src, function (res, err) {
-    if (err) {
-      console.log(err);
-    }
-    cb();
-  });
+    chrome.devtools.inspectedWindow.eval(src, function (res, err) {
+        if (err) {
+            console.log(err);
+        }
+        cb();
+    });
 }


### PR DESCRIPTION
Closes #17

- un-proxies proxy objects by JSON.stringify/JSON.parsing them
- formats edited files
- refactors backend.js `data` generation per component to use `.reduce()` instead of `for of`

**Note**: proxies are undetectable so we take the serialisation/deserialisation hit for all devtools runs.