### PR TITLE
chore(panel-editing-tests)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,8 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: install
       run: npm ci
-    - name: test
-      run: npm t
+    - name: test (with coverage)
+      run: npm t -- --coverage
     - name: build
       run: npm run prod
     - name: Archive production artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist
 node_modules
 mix-manifest.json
 .DS_Store
+coverage

--- a/packages/shell-chrome/assets/panel.html
+++ b/packages/shell-chrome/assets/panel.html
@@ -82,6 +82,7 @@
                                     x-show="!singleData.hasArrow && !singleData.readOnly && singleData.isOpened">
                                     <svg fill="none" stroke="currentColor" stroke-linecap="round"
                                         x-show="!singleData.inEditingMode"
+                                        data-testid="edit-icon"
                                         @click="alpineState.editAttribute(singleData)" stroke-linejoin="round"
                                         stroke-width="2" viewBox="0 0 24 24"
                                         class="w-4 h-4 cursor-pointer hover:bg-blue-100">
@@ -96,8 +97,9 @@
                                             :type="singleData.inputType" x-model="singleData.editAttributeValue">
 
                                         <svg x-show="singleData.inEditingMode" fill="none" stroke="currentColor"
-                                            @click="alpineState.saveEditing(singleData)" stroke-linecap="round"
-                                            stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24"
+                                            data-testid="save-icon" @click="alpineState.saveEditing(singleData)"
+                                            stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                            viewBox="0 0 24 24"
                                             class="flex w-6 h-6 cursor-pointer ml-2 hover:bg-blue-100">
                                             <path
                                                 d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4">
@@ -105,8 +107,9 @@
                                         </svg>
 
                                         <svg x-show="singleData.inEditingMode" fill="none" stroke="currentColor"
-                                            stroke-linecap="round" @click="alpineState.cancelEditing(singleData)"
-                                            stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24"
+                                            data-testid="cancel-icon" stroke-linecap="round"
+                                            @click="alpineState.cancelEditing(singleData)" stroke-linejoin="round"
+                                            stroke-width="2" viewBox="0 0 24 24"
                                             class="flex w-6 h-6 ml-2 cursor-pointer hover:bg-blue-100">
                                             <path
                                                 d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z">

--- a/tests/component-list.spec.js
+++ b/tests/component-list.spec.js
@@ -1,8 +1,6 @@
-import '@testing-library/jest-dom';
 import Alpine from 'alpinejs';
-import { waitFor, queryAllByTestId, getAllByTestId, getByTestId, getNodeText } from '@testing-library/dom';
-import { getPanelHtml, createComponent } from './utils';
-import State from '../packages/shell-chrome/src/state';
+import { waitFor } from '@testing-library/dom';
+import { getPanelHtml, createComponent, State } from './utils';
 
 test('component list > single component', async () => {
     const alpineState = new State();
@@ -11,17 +9,17 @@ test('component list > single component', async () => {
 
     Alpine.start();
 
-    expect(queryAllByTestId(document.body, 'component-name')).toHaveLength(0);
+    expect(document.querySelectorAll('[data-testid=component-name]')).toHaveLength(0);
 
     alpineState.renderComponentsFromBackend([
-        createComponent('DIV', { bool: false })
+        createComponent('DIV', { property: 'some-value' })
     ]);
 
     await waitFor(() => {
-        expect(getAllByTestId(document.body, 'component-name')).toHaveLength(1);
+        expect(document.querySelectorAll('[data-testid=component-name]')).toHaveLength(1);
     });
 
-    expect(getByTestId(document.body, 'component-name').innerText).toEqual('DIV');
+    expect(document.querySelectorAll('[data-testid=component-name]')[0].innerText).toEqual('DIV');
 });
 
 test('component list > clicking on the component opens the data tab', async () => {
@@ -31,21 +29,22 @@ test('component list > clicking on the component opens the data tab', async () =
 
     Alpine.start();
     alpineState.renderComponentsFromBackend([
-        createComponent('DIV', { bool: false })
+        createComponent('DIV', { property: 'some-value' })
     ]);
 
     await waitFor(() => {
-        expect(getAllByTestId(document.body, 'component-name')).toHaveLength(1);
+
+        expect(document.querySelectorAll('[data-testid=component-name]')).toHaveLength(1);
     });
 
-    expect(getByTestId(document.body, 'data-property')).not.toBeVisible();
+    expect(document.querySelector('[data-testid=data-property]')).not.toBeVisible();
 
-    getByTestId(document.body, 'component-name').click();
+    document.querySelector('[data-testid=component-name]').click()
 
     await waitFor(() => {
-        expect(getByTestId(document.body, 'data-property')).toBeVisible();
+        expect(document.querySelector('[data-testid=data-property]')).toBeVisible();
     });
 
-    expect(getByTestId(document.body, 'data-property-name').innerText).toEqual('bool');
-    expect(getByTestId(document.body, 'data-property-value').innerText).toEqual(false);
+    expect(document.querySelector('[data-testid=data-property-name]').innerText).toEqual('property');
+    expect(document.querySelector('[data-testid=data-property-value]').innerText).toEqual('some-value');
 });

--- a/tests/component-list.spec.js
+++ b/tests/component-list.spec.js
@@ -19,7 +19,7 @@ test('component list > single component', async () => {
         expect(document.querySelectorAll('[data-testid=component-name]')).toHaveLength(1);
     });
 
-    expect(document.querySelectorAll('[data-testid=component-name]')[0].innerText).toEqual('DIV');
+    expect(document.querySelector('[data-testid=component-name]').innerText).toEqual('DIV');
 });
 
 test('component list > clicking on the component opens the data tab', async () => {

--- a/tests/editing.spec.js
+++ b/tests/editing.spec.js
@@ -1,0 +1,166 @@
+import Alpine from 'alpinejs';
+import { waitFor, fireEvent } from '@testing-library/dom';
+import { getPanelHtml, createComponent, mockDevtoolPostMessage, State } from './utils';
+
+
+async function openSingleComponentWithEditableField() {
+    await waitFor(() => {
+        expect(document.querySelectorAll('[data-testid=component-name]')).toHaveLength(1);
+    });
+
+    document.querySelector('[data-testid=component-name]').click();
+
+    await waitFor(() => {
+        expect(document.querySelectorAll('[data-testid=data-property]')).toHaveLength(1);
+        expect(document.querySelector('[data-testid=data-property-name]').innerText).toBeDefined();
+        expect(document.querySelector('[data-testid=edit-icon]')).toBeVisible();
+    });
+}
+
+async function saveSingleProperty(document) {
+    const saveIcon = document.querySelector('[data-testid=save-icon]');
+    expect(saveIcon).toBeVisible();
+    fireEvent.click(saveIcon);
+
+    await waitFor(() => expect(saveIcon).not.toBeVisible());
+}
+
+test('editing a string', async () => {
+    const mockPostMessage = mockDevtoolPostMessage(window);
+    const alpineState = new State();
+    window.alpineState = alpineState;
+    document.body.innerHTML = getPanelHtml();
+
+    Alpine.start();
+    alpineState.renderComponentsFromBackend([
+        createComponent('DIV', { str: 'some-string' })
+    ]);
+
+    await openSingleComponentWithEditableField();
+
+    fireEvent.click(document.querySelector('[data-testid=edit-icon]'));
+
+    const input = document.querySelector('input');
+
+    await waitFor(() => {
+        expect(input).toBeVisible();
+        expect(input.type).toEqual('text');
+        expect(input.value).toEqual('some-string');
+    });
+
+
+    fireEvent.input(input, { target: { value: 'new-string' } });
+    await waitFor(() => expect(input.value).toEqual('new-string'))
+
+    await saveSingleProperty(document);
+
+    expect(mockPostMessage).toHaveBeenCalledTimes(1);
+    expect(mockPostMessage).toHaveBeenCalledWith({
+        action: "editAttribute",
+        attributeSequence: "str",
+        attributeValue: "new-string",
+        componentId: "component-id",
+        source: "alpineDevtool",
+    });
+});
+test('editing a number', async () => {
+    const mockPostMessage = mockDevtoolPostMessage(window);
+    const alpineState = new State();
+    window.alpineState = alpineState;
+    document.body.innerHTML = getPanelHtml();
+
+    Alpine.start();
+    alpineState.renderComponentsFromBackend([
+        createComponent('DIV', { num: 15 })
+    ]);
+
+    await openSingleComponentWithEditableField();
+
+    fireEvent.click(document.querySelector('[data-testid=edit-icon]'));
+
+    const input = document.querySelector('input');
+
+    await waitFor(() => {
+        expect(input).toBeVisible();
+        expect(input.type).toEqual('number');
+        expect(input.value).toEqual('15');
+    });
+
+
+    fireEvent.input(input, { target: { value: 22 } });
+    await waitFor(() => expect(input.value).toEqual('22'))
+
+    await saveSingleProperty(document);
+
+    expect(mockPostMessage).toHaveBeenCalledTimes(1);
+    expect(mockPostMessage).toHaveBeenCalledWith({
+        action: "editAttribute",
+        attributeSequence: "num",
+        attributeValue: 22,
+        componentId: "component-id",
+        source: "alpineDevtool",
+    });
+});
+test('editing a boolean', async () => {
+    const mockPostMessage = mockDevtoolPostMessage(window);
+    const alpineState = new State();
+    window.alpineState = alpineState;
+    document.body.innerHTML = getPanelHtml();
+
+    Alpine.start();
+    alpineState.renderComponentsFromBackend([
+        createComponent('DIV', { bool: false })
+    ]);
+
+    await openSingleComponentWithEditableField();
+
+    fireEvent.click(document.querySelector('[data-testid=edit-icon]'));
+
+    const input = document.querySelector('input');
+
+    await waitFor(() => {
+        expect(input).toBeVisible();
+        expect(input.type).toEqual('checkbox');
+        expect(input.checked).toEqual(false);
+    });
+
+
+    fireEvent.click(input);
+    await waitFor(() => expect(input.checked).toEqual(true))
+
+    await saveSingleProperty(document);
+
+    expect(mockPostMessage).toHaveBeenCalledTimes(1);
+    expect(mockPostMessage).toHaveBeenCalledWith({
+        action: "editAttribute",
+        attributeSequence: "bool",
+        attributeValue: true,
+        componentId: "component-id",
+        source: "alpineDevtool",
+    });
+});
+test('function properties are read-only', async () => {
+    const alpineState = new State();
+    window.alpineState = alpineState;
+    document.body.innerHTML = getPanelHtml();
+
+    Alpine.start();
+    alpineState.renderComponentsFromBackend([
+        createComponent('DIV', { myFn() { /* do something */ } })
+    ]);
+
+    await waitFor(() => {
+        expect(document.querySelectorAll('[data-testid=component-name]')).toHaveLength(1);
+    });
+
+    document.querySelector('[data-testid=component-name]').click();
+
+    await waitFor(() => {
+        expect(document.querySelectorAll('[data-testid=data-property]')).toHaveLength(1);
+        expect(document.querySelector('[data-testid=data-property-name]').innerText).toBeDefined();
+    });
+
+    expect(document.querySelector('[data-testid=data-property-name]').innerText).toEqual('myFn');
+    expect(document.querySelector('[data-testid=data-property-value]').innerText).toEqual('function');
+    expect(document.querySelector('[data-testid=edit-icon]')).not.toBeVisible();
+});

--- a/tests/init.spec.js
+++ b/tests/init.spec.js
@@ -2,7 +2,7 @@ import Alpine from 'alpinejs';
 import { getPanelHtml } from './utils';
 import State from '../packages/shell-chrome/src/state';
 
-test('initialisation > sanity check that the empty panel initialises without error', async () => {
+test('initialisation, the "panel" Alpine app launches without error', async () => {
     const alpineState = new State();
     window.alpineState = alpineState;
     document.body.innerHTML = getPanelHtml();

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -18,6 +18,16 @@ export function getPanelHtml() {
     return panelHtml;
 }
 
+export function mockDevtoolPostMessage(window) {
+    const stub = jest.fn();
+    window.__alpineDevtool = {
+        port: {
+            postMessage: stub
+        }
+    };
+    return stub;
+}
+
 export function createComponent(tagName = 'DIV', data = {}, { id = 'component-id', index = 0, depth = 0 } = {}) {
     return {
         index,

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -1,7 +1,9 @@
+import '@testing-library/jest-dom';
 import fs from 'fs';
 
-const bodyContentRegex = /(?<=(\<body\>)).*(?=(<\/body>))/gms
+export { default as State } from '../packages/shell-chrome/src/state';
 
+const bodyContentRegex = /(?<=(\<body\>)).*(?=(<\/body>))/gms
 let panelHtml = '';
 
 export function getPanelHtml() {


### PR DESCRIPTION
Part 2/3 of #37 

- Test that editing strings, numbers, booleans works as expected.
- Test that functions are read-only
- Test that cancelling works as expected
- Add a new util to mock `window.__alpineDevtool.port.postMessage`
- Enable coverage on CI test runs
- Refactor testing
  - move jest-dom import to test/utils
  - re-export State from test/utils (cleaner test files)
  - move away from dom-testing-library query fns in favour of querySelector