### PR TITLE
fix(csp-only-self-unsafe-inline)

### DIFF
--- a/packages/shell-chrome/assets/manifest.json
+++ b/packages/shell-chrome/assets/manifest.json
@@ -34,7 +34,7 @@
     "backend.js"
   ],
 
-  "content_security_policy": "script-src 'self' 'unsafe-eval'  https://cdn.jsdelivr.net; object-src",
+  "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src",
   "content_scripts": [
     {
       "matches": [


### PR DESCRIPTION
From a Firefox addon reviewer:

> This version did not pass the review because of the following issues:
> 1) Extensions defining a content security policy that allows eval ('unsafe-eval') are generally not allowed for security and performance reasons. eval is only necessary in rare cases. 
>
> 2) Using a custom CSP to allow remote script execution is not allowed. We don't allow add-ons to use remote scripts because they can create serious security vulnerabilities.

Remove JSDeliver from allows origins (we're bundling Alpine anyways).