### PR TITLE
feat(inject-pkg-version-in-manifest) chore(zip-extension-in-ci)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,9 +25,9 @@ jobs:
     - name: test (with coverage)
       run: npm t -- --coverage
     - name: build
-      run: npm run prod
+      run: npm run package
     - name: Archive production artifacts
       uses: actions/upload-artifact@v1
       with:
         name: alpine-devtools
-        path: dist/chrome
+        path: dist

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
         "dev": "rollup -c",
         "prod": "NODE_ENV=production rollup -c",
         "watch": "rollup -c -w",
-        "test": "jest"
+        "test": "jest",
+        "prepackage": "npm run prod",
+        "package": "cd ./dist/chrome && zip -r ../alpine-devtools-$npm_package_version.zip ."
     },
     "license": "MIT",
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "watch": "rollup -c -w",
         "test": "jest",
         "prepackage": "npm run prod",
-        "package": "cd ./dist/chrome && zip -r ../alpine-devtools-$npm_package_version.zip ."
+        "package": "cd ./dist/chrome && zip -r ../alpine-devtools-$npm_package_version.zip . && rm -rf ../chrome"
     },
     "license": "MIT",
     "devDependencies": {

--- a/packages/shell-chrome/assets/manifest.json
+++ b/packages/shell-chrome/assets/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Alpine.js devtools",
   "description": "DevTools extension for debugging Alpine.js applications.",
-  "version": "0.0.3",
+  "version": "__version__",
   "manifest_version": 2,
   "icons": {
     "16": "icons/16.png",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,6 +3,7 @@ import copy from 'rollup-plugin-copy'
 import { terser } from 'rollup-plugin-terser'
 import resolve from '@rollup/plugin-node-resolve'
 import postcss from 'rollup-plugin-postcss'
+import pkg from './package.json'
 
 export default {
     input: [
@@ -24,7 +25,18 @@ export default {
         postcss(),
         copy({
             targets: [
-                { src: 'packages/shell-chrome/assets/**/*', dest: 'dist/chrome' }
+                {
+                    src: 'packages/shell-chrome/assets/**/*',
+                    dest: 'dist/chrome',
+                },
+                {
+                    src: 'packages/shell-chrome/assets/manifest.json',
+                    dest: 'dist/chrome',
+                    // inject version into manifest
+                    transform(contents) {
+                        return contents.toString().replace('__version__', pkg.version)
+                    }
+                }
             ]
         }),
         filesize(),


### PR DESCRIPTION
cc @ryangjchandler but I think this Closes #15 apart from automatic publishing, we've now got it to the point where each commit is tested, built and a versioned artifact ready to upload to Firefox addons gallery is generated.

**Question**: should we delete the `dist/chrome` directory once it's zipped up instead of saving it?

- inject package.json "version" field into manifest at build-time, this means we can use `npm version [patch|minor|major]` and CI takes care of the rest
- add a `package` script (works on *NIX envs) to build & zip extension
- run `npm run package` instead of `npm run prod` in CI to store a ready to submit zip file with the extension as well as bundled code.